### PR TITLE
feat(snapshot): Add list, status, and delete snapshot features

### DIFF
--- a/src/core/models.rs
+++ b/src/core/models.rs
@@ -45,3 +45,20 @@ pub struct RestoreReport {
     pub deleted: Vec<String>,
     pub unchanged: Vec<String>,
 }
+
+
+pub struct SnapshotListInfo {
+    pub id: usize,
+    pub timestamp: String,
+    pub changes: usize,
+    pub total_size: u64,
+}
+
+pub struct StatusInfo {
+    pub has_uncommitted_changes: bool,
+    pub modified_files: Vec<String>,
+    pub new_files: Vec<String>,
+    pub deleted_files: Vec<String>,
+    pub available_space: u64,
+    pub latest_snapshot_id: Option<usize>,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,26 @@ enum Commands {
         #[arg(value_name = "DIRECTORY")]
         dir: String,
     },
+    List {
+        #[arg(value_name = "DIRECTORY")]
+        dir: String,
+        /// Show detailed information including space usage
+        #[arg(long, default_value_t = false)]
+        detailed: bool,
+    },
+    Status {
+        #[arg(value_name = "DIRECTORY")]
+        dir: String,
+    },
+    Delete {
+        #[arg(value_name = "DIRECTORY")]
+        dir: String,
+        #[arg(value_name = "SNAPSHOT_ID")]
+        snapshot_id: usize,
+        /// Clean up unused content after deletion
+        #[arg(long, default_value_t = false)]
+        cleanup: bool,
+    },
     Diff {
         #[arg(value_name = "DIRECTORY")]
         dir: String,
@@ -55,6 +75,76 @@ fn main() {
                 dir, e
             ),
         },
+        Commands::List { dir, detailed } => match timemachine::list_snapshots(dir, *detailed) {
+            Ok(snapshots) => {
+                if snapshots.is_empty() {
+                    eprintln!("No snapshots found in {}", dir);
+                } else {
+                    eprintln!("Snapshots in {}:", dir);
+                    for snapshot in snapshots {
+                        if *detailed {
+                            eprintln!(
+                                "ID: {}, Time: {}, Changes: {}, Size: {} bytes",
+                                snapshot.id, snapshot.timestamp, snapshot.changes, snapshot.total_size
+                            );
+                        } else {
+                            eprintln!(
+                                "ID: {}, Time: {}, Changes: {}",
+                                snapshot.id, snapshot.timestamp, snapshot.changes
+                            );
+                        }
+                    }
+                }
+            }
+            Err(e) => eprintln!(
+                "Failed to list snapshots in directory '{}': {}",
+                dir, e
+            ),
+        },
+        Commands::Status { dir } => match timemachine::get_status(dir) {
+            Ok(status) => {
+                eprintln!("Status for {}:", dir);
+                if let Some(id) = status.latest_snapshot_id {
+                    eprintln!("Latest snapshot: {}", id);
+                } else {
+                    eprintln!("No snapshots found");
+                }
+                eprintln!("Available space: {} bytes", status.available_space);
+                
+                if status.has_uncommitted_changes {
+                    eprintln!("\nUncommitted changes:");
+                    if !status.modified_files.is_empty() {
+                        eprintln!("Modified files: {:?}", status.modified_files);
+                    }
+                    if !status.new_files.is_empty() {
+                        eprintln!("New files: {:?}", status.new_files);
+                    }
+                    if !status.deleted_files.is_empty() {
+                        eprintln!("Deleted files: {:?}", status.deleted_files);
+                    }
+                } else {
+                    eprintln!("\nWorking directory is clean");
+                }
+            }
+            Err(e) => eprintln!(
+                "Failed to get status for directory '{}': {}",
+                dir, e
+            ),
+        },
+        Commands::Delete { dir, snapshot_id, cleanup } => {
+            match timemachine::delete_snapshot(dir, *snapshot_id, *cleanup) {
+                Ok(_) => {
+                    eprintln!("Successfully deleted snapshot {}", snapshot_id);
+                    if *cleanup {
+                        eprintln!("Cleaned up unused content");
+                    }
+                }
+                Err(e) => eprintln!(
+                    "Failed to delete snapshot {} in directory '{}': {}",
+                    snapshot_id, dir, e
+                ),
+            }
+        },
         Commands::Diff {
             dir,
             snapshot_id1,
@@ -78,33 +168,33 @@ fn main() {
             dir,
             snapshot_id,
             dry_run,
-        } => {
-            // Now proceed with restore
-            match timemachine::restore_snapshot(dir, *snapshot_id, *dry_run) {
-                Ok(report) => {
-                    if report.added.is_empty() && report.modified.is_empty() && report.deleted.is_empty() {
-                        eprintln!("No changes needed - files are already at the target state.");
-                    } else {
-                        eprintln!("Changes to be made:");
-                        if !report.added.is_empty() {
-                            eprintln!("Files to add: {:?}", report.added);
-                        }
-                        if !report.modified.is_empty() {
-                            eprintln!("Files to modify: {:?}", report.modified);
-                        }
-                        if !report.deleted.is_empty() {
-                            eprintln!("Files to delete: {:?}", report.deleted);
-                        }
+        } => match timemachine::restore_snapshot(dir, *snapshot_id, *dry_run) {
+            Ok(report) => {
+                if report.added.is_empty() && report.modified.is_empty() && report.deleted.is_empty() {
+                    eprintln!("No changes needed - files are already at the target state.");
+                } else {
+                    eprintln!("Changes to be made:");
+                    if !report.added.is_empty() {
+                        eprintln!("Files to add: {:?}", report.added);
                     }
-
-                    if *dry_run {
-                        eprintln!("Dry run complete. No changes were made.");
-                    } else {
-                        eprintln!("Restore completed successfully!");
+                    if !report.modified.is_empty() {
+                        eprintln!("Files to modify: {:?}", report.modified);
+                    }
+                    if !report.deleted.is_empty() {
+                        eprintln!("Files to delete: {:?}", report.deleted);
                     }
                 }
-                Err(e) => eprintln!("Error: {}", e),
+
+                if *dry_run {
+                    eprintln!("Dry run complete. No changes were made.");
+                } else {
+                    eprintln!("Restore complete.");
+                }
             }
-        }
+            Err(e) => eprintln!(
+                "Failed to restore snapshot {} in directory '{}': {}",
+                snapshot_id, dir, e
+            ),
+        },
     }
 }


### PR DESCRIPTION
Implements core snapshot management functionality to enhance user control over snapshots:

- List snapshots: View all snapshots with optional detailed size information
- Status check: Compare current state with latest snapshot and show disk space
- Delete snapshots: Remove specific snapshots with optional content cleanup

Key implementation details:
- Snapshots are identified by incremental IDs based on existing count
- Status includes uncommitted changes, disk space, and latest snapshot ID
- Delete operation supports optional cleanup of unused content
- All operations maintain metadata integrity in .timemachine/metadata.json

Testing:
- Added comprehensive tests for list, status, and delete operations
- Tests cover edge cases like non-existent snapshots and disk space checks

